### PR TITLE
Use double quotes for RVM_HOME

### DIFF
--- a/vars/withRvm.groovy
+++ b/vars/withRvm.groovy
@@ -5,7 +5,7 @@ def call(String version, Closure cl) {
 }
 
 def call(String version, String gemset, Closure cl) {
-    final RVM_HOME = '$HOME/.rvm'
+    final RVM_HOME = "${env.HOME}/.rvm"
     paths = [
         "$RVM_HOME/gems/$version@$gemset/bin",
         "$RVM_HOME/gems/$version@global/bin",


### PR DESCRIPTION
I'm not actually sure the best practice here, I'm a bit shaky on shell substitutions... But I'm seeing gems being put into a directory named '$HOME' rather than into my home directory. Maybe $RVM_HOME needs to be substituted differently in the second withEnv? Some of these environment variables end up literally having the string "$HOME" in them and I'm not sure RVM or Ruby is handling that gracefully.